### PR TITLE
Use dsn string from db config if available

### DIFF
--- a/application/tests/CIDatabaseTestCase.php
+++ b/application/tests/CIDatabaseTestCase.php
@@ -2,28 +2,28 @@
 
 /**
  * Base class for CodeIgniter integration tests
- * 
+ *
  * This class wraps $CI reference for communicating with CodeIgniter,
- * as well as helping to load controllers and initializing database connection for assertions 
- * 
+ * as well as helping to load controllers and initializing database connection for assertions
+ *
  * @author		Fernando Piancastelli
  * @link		https://github.com/fmalk/codeigniter-phpunit
  * @link		http://www.phpunit.de/manual/3.7/en/database.html
- * 
+ *
  * @property-read resource	$db		Reference to database
  */
 abstract class CIDatabaseTestCase extends PHPUnit_Extensions_Database_TestCase
 {
 	/**
 	 * Reference to CodeIgniter
-	 * 
+	 *
 	 * @var resource
 	 */
 	protected $CI;
-	
+
 	/**
 	 * Only instantiate pdo once for test clean-up/fixture load
-	 * 
+	 *
 	 * @internal
 	 * @var resource
 	 */
@@ -31,23 +31,23 @@ abstract class CIDatabaseTestCase extends PHPUnit_Extensions_Database_TestCase
 
 	/**
 	 * Only instantiate PHPUnit_Extensions_Database_DB_IDatabaseConnection once per test
-	 * 
+	 *
 	 * @internal
 	 * @var resource
 	 */
     private $conn = null;
-	
+
 	/**
 	 * Call parent constructor and initialize reference to CodeIgniter
-	 * 
+	 *
 	 * @internal
 	 */
 	public function __construct($name = NULL, array $data = array(), $dataName = '')
     {
         parent::__construct($name, $data, $dataName);
-		$this->CI =& get_instance();	
+		$this->CI =& get_instance();
     }
-	
+
 	/**
 	 * Load a controller from your application/controllers folder, like CI Router would do.
 	 * Called with your controller class name.
@@ -65,7 +65,7 @@ abstract class CIDatabaseTestCase extends PHPUnit_Extensions_Database_TestCase
 			require_once($filepath);
 		}
 	}
-	
+
     /**
 	 * Initialize database connection (same one used by CodeIgniter)
 	 *
@@ -76,6 +76,9 @@ abstract class CIDatabaseTestCase extends PHPUnit_Extensions_Database_TestCase
         if ($this->conn === null) {
             if (self::$pdo == null) {
             	$dsn = $this->CI->db->dbdriver.':dbname='.$this->CI->db->database.';host='.$this->CI->db->hostname;
+            	if ($this->CI->db->dsn) {
+            		$dsn = $this->CI->db->dsn;
+            	}
                 self::$pdo = new PDO($dsn,$this->CI->db->username, $this->CI->db->password);
             }
             $this->conn = $this->createDefaultDBConnection(self::$pdo, $this->CI->db->database);
@@ -83,7 +86,7 @@ abstract class CIDatabaseTestCase extends PHPUnit_Extensions_Database_TestCase
 
         return $this->conn;
     }
-	
+
 	/**
 	 * @internal
 	 */
@@ -97,7 +100,7 @@ abstract class CIDatabaseTestCase extends PHPUnit_Extensions_Database_TestCase
 
     /**
 	 * Returns the DataSet
-	 * 
+	 *
 	 * Important: the returned DataSet is the current database state, meaning
 	 * this function does NOT behave as a fixture: the intended usage of this
 	 * current state connection is to do integration testing.


### PR DESCRIPTION
In case someone already using `dsn` in their [database config](bcit-ci/CodeIgniter/blob/develop/application/config/database.php#L77).

**EDIT**
My editor automatically clean up the white spaces :grin: